### PR TITLE
[#13] 중복 로그인 예외 처리 기능 추가

### DIFF
--- a/src/main/java/com/flab/doorrush/domain/user/api/GlobalExceptionHandler.java
+++ b/src/main/java/com/flab/doorrush/domain/user/api/GlobalExceptionHandler.java
@@ -2,6 +2,7 @@ package com.flab.doorrush.domain.user.api;
 
 import com.flab.doorrush.domain.user.exception.IdNotFoundException;
 import com.flab.doorrush.domain.user.exception.InvalidPasswordException;
+import com.flab.doorrush.domain.user.exception.SessionAuthenticationException;
 import com.flab.doorrush.domain.user.exception.SessionLoginIdNotFoundException;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -28,4 +29,12 @@ public class GlobalExceptionHandler {
       SessionLoginIdNotFoundException e) {
     return new ResponseEntity<>(HttpStatus.NOT_FOUND);
   }
+
+  @ExceptionHandler
+  public ResponseEntity<HttpStatus> sessionAuthenticationException(
+      SessionAuthenticationException e) {
+    return new ResponseEntity<>(HttpStatus.FORBIDDEN);
+  }
+
+
 }

--- a/src/main/java/com/flab/doorrush/domain/user/exception/SessionAuthenticationException.java
+++ b/src/main/java/com/flab/doorrush/domain/user/exception/SessionAuthenticationException.java
@@ -1,0 +1,9 @@
+package com.flab.doorrush.domain.user.exception;
+
+public class SessionAuthenticationException extends RuntimeException {
+
+  public SessionAuthenticationException(String message) {
+    super(message);
+  }
+
+}

--- a/src/main/java/com/flab/doorrush/domain/user/service/UserService.java
+++ b/src/main/java/com/flab/doorrush/domain/user/service/UserService.java
@@ -11,6 +11,7 @@ import com.flab.doorrush.domain.user.dto.LoginDto;
 import com.flab.doorrush.domain.user.exception.DuplicatedUserIdException;
 import com.flab.doorrush.domain.user.exception.IdNotFoundException;
 import com.flab.doorrush.domain.user.exception.InvalidPasswordException;
+import com.flab.doorrush.domain.user.exception.SessionAuthenticationException;
 import com.flab.doorrush.domain.user.exception.UserNotFoundException;
 import com.flab.doorrush.domain.user.exception.SessionLoginIdNotFoundException;
 import javax.servlet.http.HttpSession;
@@ -43,6 +44,10 @@ public class UserService {
 
 
   public void login(LoginDto loginDto, HttpSession session) {
+    if (loginDto.getId().equals(session.getAttribute("loginId"))) {
+      throw new SessionAuthenticationException("이미 해당 아이디로 로그인 중 입니다.");
+    }
+
     User user = userMapper.selectUserById(loginDto.getId())
         .orElseThrow(() -> new IdNotFoundException("등록된 아이디가 없습니다."));
 

--- a/src/test/java/com/flab/doorrush/domain/user/api/UserControllerTest.java
+++ b/src/test/java/com/flab/doorrush/domain/user/api/UserControllerTest.java
@@ -132,6 +132,31 @@ class UserControllerTest {
   }
 
   @Test
+  public void loginFailDuplicatedLoginTest() throws Exception {
+    // Given
+    LoginDto loginDto = new LoginDto("test1", "test1pw");
+    String content = objectMapper.writeValueAsString(loginDto);
+    MockHttpSession mockHttpSession = new MockHttpSession();
+
+    mockMvc.perform(post("/users/login").content(content)
+            .session(mockHttpSession)
+            .contentType(MediaType.APPLICATION_JSON)
+            .accept(MediaType.APPLICATION_JSON))
+        .andDo(print())
+        .andExpect(status().isOk());
+
+    // When
+    mockMvc.perform(post("/users/login").content(content)
+            .session(mockHttpSession)
+            .contentType(MediaType.APPLICATION_JSON)
+            .accept(MediaType.APPLICATION_JSON))
+        .andDo(print())
+        // Then
+        .andExpect(status().isForbidden());
+
+  }
+
+  @Test
   public void logoutSuccessTest() throws Exception {
     // Given
     MockHttpSession mockHttpSession = new MockHttpSession();

--- a/src/test/java/com/flab/doorrush/domain/user/service/UserServiceTest.java
+++ b/src/test/java/com/flab/doorrush/domain/user/service/UserServiceTest.java
@@ -116,6 +116,20 @@ class UserServiceTest {
   }
 
   @Test
+  public void loginFailDuplicatedLoginTest() {
+    // Given
+    MockHttpSession session = new MockHttpSession();
+    LoginDto loginDto = new LoginDto("test1", "test1pw");
+    userService.login(loginDto, session);
+
+    // Then
+    assertThrows(
+        com.flab.doorrush.domain.user.exception.SessionAuthenticationException.class,
+        // When
+        () -> userService.login(loginDto, session));
+  }
+
+  @Test
   public void logoutSuccessTest() {
     // Given
     MockHttpSession session = new MockHttpSession();


### PR DESCRIPTION
# [#13] 구현 내용 요약
- 중복 로그인 예외 추가
- 로그인메서드 보완, 테스트 메서드 추가 

## 리뷰 포인트 
- 중복 로그인 예외의 리턴 HttpStatus를 고민 끝에 FORBIDDEN으로 설정했습니다. 리뷰 부탁드립니다.

## 체크 포인트
- [X] annotation 설명 주석 달기 
- [ ] 코드 컨벤션 지키기
- [X] 과도한 축약용어 사용하지 않기
- [X] 객체지향적인 코드 작성
